### PR TITLE
feat: add register and login endpoints using Supabase Auth, closes #4

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -2,8 +2,10 @@ const express = require('express');
 const app = express();
 const PORT = 3000;
 const supabase = require('./supabase');
+const authRouter = require('./routes/auth');
 
 app.use(express.json());
+app.use('/auth', authRouter);
 
 app.get('/health', (req, res) => {
   res.json({ status: 'ok' });

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -1,0 +1,37 @@
+const express = require('express');
+const router = express.Router();
+const supabase = require('../supabase');
+
+router.post('/register', async (req, res) => {
+  const { email, password } = req.body;
+
+  if (!email || !password) {
+    return res.status(400).json({ error: 'Email and password are required' });
+  }
+
+  const { data, error } = await supabase.auth.signUp({ email, password });
+
+  if (error) {
+    return res.status(400).json({ error: error.message });
+  }
+
+  res.status(201).json({ message: 'User registered successfully', data });
+});
+
+router.post('/login', async (req, res) => {
+  const { email, password } = req.body;
+
+  if (!email || !password) {
+    return res.status(400).json({ error: 'Email and password are required' });
+  }
+
+  const { data, error } = await supabase.auth.signInWithPassword({ email, password });
+
+  if (error) {
+    return res.status(400).json({ error: error.message });
+  }
+
+  res.json({ message: 'Login successful', token: data.session.access_token });
+});
+
+module.exports = router;


### PR DESCRIPTION
Closes #4

- Added POST /auth/register endpoint using supabase.auth.signUp
- Added POST /auth/login endpoint using supabase.auth.signInWithPassword
- Routes organised in server/routes/auth.js using Express Router
- Login returns JWT access token on success
- Both endpoints validate that email and password are present