### PR TITLE
feat: add forgot password endpoint using Supabase Auth

### DIFF
--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -34,4 +34,20 @@ router.post('/login', async (req, res) => {
   res.json({ message: 'Login successful', token: data.session.access_token });
 });
 
+router.post('/forgot-password', async (req, res) => {
+  const { email } = req.body;
+
+  if (!email) {
+    return res.status(400).json({ error: 'Email is required' });
+  }
+
+  const { error } = await supabase.auth.resetPasswordForEmail(email);
+
+  if (error) {
+    return res.status(400).json({ error: error.message });
+  }
+
+  res.json({ message: 'If this email is registered, a reset link has been sent.' });
+});
+
 module.exports = router;


### PR DESCRIPTION
- Added POST /auth/forgot-password endpoint
- Calls supabase.auth.resetPasswordForEmail()
- Returns generic success message regardless of whether email exists (security best practice)