### PR TITLE
feat: add forgot password form to login page

### DIFF
--- a/client/src/pages/Login.jsx
+++ b/client/src/pages/Login.jsx
@@ -5,6 +5,7 @@ function Login() {
     const [email, setEmail] = useState('')
     const [password, setPassword] = useState('')
     const [message, setMessage] = useState('')
+    const [showForgotPassword, setShowForgotPassword] = useState(false)
     const navigate = useNavigate()
 
     const handleSubmit = async (e) => {
@@ -22,6 +23,41 @@ function Login() {
             setMessage(data.error)
         }
     }
+
+    const handleForgotPassword = async (e) => {
+        e.preventDefault()
+        const response = await fetch('https://modmapperorbital2026-production.up.railway.app/auth/forgot-password', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ email })
+        })
+        const data = await response.json()
+        if (response.ok) {
+            setMessage(data.message)
+        } else {
+            setMessage(data.error)
+        }
+    }
+
+    if (showForgotPassword) {
+        return (
+            <div>
+                <h1>Reset Password</h1>
+                <form onSubmit={handleForgotPassword}>
+                    <input
+                        type="email"
+                        placeholder="Email"
+                        value={email}
+                        onChange={(e) => setEmail(e.target.value)}
+                    />
+                    <button type="submit">Send Reset Link</button>
+                </form>
+                <p>{message}</p>
+                <button onClick={() => setShowForgotPassword(false)}>Back to Login</button>
+            </div>
+        )
+    }
+
 
     return (
         <div>
@@ -42,6 +78,7 @@ function Login() {
                 <button type="submit">Login</button>
             </form>
             <p>{message}</p>
+            <button onClick={() => setShowForgotPassword(true)}>Forgot Password</button>
         </div>
     )
 }


### PR DESCRIPTION
Closes #16

- Added forgot password button to login page
- Clicking it shows a reset password form
- On submit, calls POST /auth/forgot-password endpoint
- Supabase sends reset email successfully
- Back to Login button returns to main login form