### PR TITLE
feat: module search page using NUSMods API

### DIFF
--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -97,7 +97,7 @@ function Dashboard() {
                 <div style={s.navItem}><div style={s.navDot}></div>4-Year Planner</div>
 
                 <div style={s.navLabel}>Explore</div>
-                <div style={s.navItem}><div style={s.navDot}></div>Module Search</div>
+                <div style={s.navItem} onClick={() => navigate('/modules')}><div style={s.navDot}></div>Module Search</div>
                 <div style={s.navItem}><div style={s.navDot}></div>UE Recommender</div>
                 <div style={s.navItem}><div style={s.navDot}></div>Q&A Community</div>
 

--- a/client/src/pages/ModuleSearch.jsx
+++ b/client/src/pages/ModuleSearch.jsx
@@ -1,0 +1,43 @@
+import { useState, useEffect } from 'react'
+
+function ModuleSearch() {
+    const [modules, setModules] = useState([])
+    const [query, setQuery] = useState('')
+    const [loading, setLoading] = useState(true)
+
+    useEffect(() => {
+        fetch('https://api.nusmods.com/v2/2024-2025/moduleList.json')
+            .then(res => res.json())
+            .then(data => {
+                setModules(data)
+                setLoading(false)
+            })
+    }, [])
+
+    const filtered = modules.filter(mod =>
+        mod.moduleCode.toLowerCase().includes(query.toLowerCase()) ||
+        mod.title.toLowerCase().includes(query.toLowerCase())
+    )
+
+    if (loading) return <div>Loading mods...</div>
+
+    return (
+        <div>
+            <h1>Module Search</h1>
+            <input
+                type="text"
+                placeholder="Search by code or name..."
+                value={query}
+                onChange={e => setQuery(e.target.value)}
+            />
+            <p>{filtered.length} modules found</p>
+            {filtered.slice(0, 20).map(mod => (
+                <div key={mod.moduleCode}>
+                    <strong>{mod.moduleCode}</strong> — {mod.title}
+                </div>
+            ))}
+        </div>
+    )
+}
+
+export default ModuleSearch


### PR DESCRIPTION
Closes #25 

Adds a Module Search page with features like:
- live search against NUSMods API across thousands of mods
- filter by module name or code
- auth protection added later (redirected to login if no token)
- sidebar navigation link added to Dashboard 