### PR TITLE
Add prereq tree feature with nOf support, closes #49

### DIFF
--- a/server/db/prereqTree.js
+++ b/server/db/prereqTree.js
@@ -1,0 +1,420 @@
+const supabase = require('./supabase');
+
+async function checkPrereq(moduleCode, prereqModule) {
+    const { data, error } = await supabase
+        .from('modules')
+        .select('prereq_tree')
+        .eq('module_code', moduleCode)
+        .maybeSingle();
+
+    if (error) {
+        throw new Error(`Error fetching timetable: ${error.message}`);
+    }
+
+    if (!data) {
+        return false;
+    }
+
+    const tree = data.prereq_tree;
+
+    if(!tree) {
+        return false;
+    }
+
+    if (tree.or) {
+        return tree.or.some(x =>
+            x?.nOf
+                ? n0f(x, prereqModule)
+                : matches(prereqModule, x)
+        );
+    }
+
+    if (tree.and) {
+        return tree.and.some(group =>
+            group.or?.some(x =>
+                x?.nOf
+                    ? n0f(x, prereqModule)
+                    : matches(prereqModule, x)
+            )
+        );
+    }
+
+    return false;
+}
+
+function n0f(node, moduleCode) {
+    const [, modules] = node.nOf;
+
+    return modules.some(m => matches(moduleCode, m));
+}
+
+
+function matches(prereq, candidate) {
+    if (typeof candidate !== 'string') {
+        return false;
+    }
+
+    const clean = candidate.replace(':D', '');
+
+    if (clean.endsWith('%')) {
+        return prereq.startsWith(clean.slice(0, -1));
+    }
+
+    return clean === prereq;
+}
+
+async function numPrereq (moduleCode) {
+    const { data, error } = await supabase
+        .from('modules')
+        .select('prereq_tree')
+        .eq('module_code', moduleCode)
+        .maybeSingle();
+    
+    if (error) {
+        throw new Error(`Error fetching timetable: ${error.message}`);
+    }
+    
+    if (!data) {
+        return 0;
+    }
+
+    const tree = data.prereq_tree;
+
+    if (!tree) {
+        return 0;
+    }
+    if (tree.or) {
+        return 1;
+    }
+    else {
+        let count = 0;
+        for (const temp of tree.and) {
+            count++;
+        }
+        return count;
+    }
+    
+}
+
+async function checkPreclusion (moduleCode, precModule) {
+    const { data, error } = await supabase
+        .from('modules')
+        .select('preclusion')
+        .eq('module_code', moduleCode)
+        .maybeSingle();
+
+    if (error) {
+        throw new Error(`Error fetching timetable: ${error.message}`);
+    }
+
+    return data?.preclusion?.includes(precModule) ?? false;
+}
+
+async function fulfillReq (moduleCode) {
+    const { data, error } = await supabase
+        .from('modules')
+        .select('fulfill_requirements')
+        .eq('module_code', moduleCode)
+
+    if (error) {
+        throw new Error(`Error fetching timetable: ${error.message}`);
+    }
+    
+    return data;
+}
+
+
+async function UserPrereqTree(userId) {
+    const { data: takenModules, error } = await supabase
+        .from('plan_modules')
+        .select('module_code')
+        .eq('user_id', userId)
+        .eq('status', 'taken');
+
+    if (error) {
+        throw new Error(`Error fetching taken modules: ${error.message}`);
+    }
+
+    const moduleCodes = takenModules.map(x => x.module_code);
+
+    if (moduleCodes.length === 0) {
+        return {};
+    }
+
+    const { data: moduleData, error: moduleError } = await supabase
+        .from('modules')
+        .select('module_code, prereq_tree')
+        .in('module_code', moduleCodes);
+
+    if (moduleError) {
+        throw new Error(`Error fetching prerequisite trees: ${moduleError.message}`);
+    }
+
+    const prereqMap = {};
+    for (const row of moduleData) {
+        prereqMap[row.module_code] = row.prereq_tree;
+    }
+
+    const ans = {};
+
+    for (const moduleCode of moduleCodes) {
+        ans[moduleCode] = [];
+
+        const tree = prereqMap[moduleCode];
+
+        if (!tree) {
+            continue;
+        }
+
+        for (const prereqModule of moduleCodes) {
+            let found = false;
+
+            if (tree.or) {
+                found = tree.or.some(x =>
+                    x?.nOf
+                        ? n0f(x, prereqModule)
+                        : matches(prereqModule, x)
+                );
+            } else if (tree.and) {
+                found = tree.and.some(group =>
+                    group.or?.some(x =>
+                        x?.nOf
+                            ? n0f(x, prereqModule)
+                            : matches(prereqModule, x)
+                    )
+                );
+            }
+
+            if (found) {
+                ans[moduleCode].push(prereqModule);
+            }
+        }
+    }
+
+    return ans;
+}
+
+
+
+
+async function getPrereqModuleCodes(moduleCode) {
+    const { data, error } = await supabase
+        .from('modules')
+        .select('prereq_tree')
+        .eq('module_code', moduleCode)
+        .maybeSingle();
+
+    if (error) {
+        throw new Error(`Error fetching timetable: ${error.message}`);
+    }
+
+    if (!data) {
+        return {};
+    }
+
+    const tree = data.prereq_tree;
+    let ans = {};
+
+    const extract = x => {
+        if (x?.nOf) {
+            return x;
+        }
+
+        return (
+            x.match(/[A-Z]{2,4}\d{4}[A-Z]{0,3}%?/)?.[0]
+            ?? null
+        );
+    };
+
+    if (!tree) {
+        return ans;
+    }
+
+    if (tree.or) {
+        ans[1] = tree.or
+            .map(extract)
+            .filter(Boolean);
+    } else {
+        let count = 1;
+
+        for (const group of tree.and) {
+            ans[count] = group.or
+                .map(extract)
+                .filter(Boolean);
+
+            count++;
+        }
+    }
+
+    return ans;
+}
+
+async function missingPrereq(userId, moduleCode) {
+    const { data, error } = await supabase
+        .from('plan_modules')
+        .select('module_code')
+        .eq('user_id', userId)
+        .eq('status', 'taken');
+
+    if (error) {
+        throw new Error(`Error fetching taken modules: ${error.message}`);
+    }
+
+    const taken = data.map(x => x.module_code);
+    const need = await getPrereqModuleCodes(moduleCode);
+
+    const ans = [];
+
+    for (const group of Object.values(need)) {
+        let satisfied = false;
+        const missing = [];
+
+        for (const t of group) {
+
+            if (t?.nOf) {
+                const [required, modules] = t.nOf;
+
+                const completed = modules.filter(m =>
+                    taken.some(mod => matches(mod, m))
+                ).length;
+
+                if (completed >= required) {
+                    satisfied = true;
+                    break;
+                }
+
+                const remaining = modules
+                    .filter(m =>
+                        !taken.some(mod => matches(mod, m))
+                    )
+                    .map(m => m.replace(':D', ''));
+
+                missing.push({
+                    need: required - completed,
+                    choices: remaining
+                });
+
+                continue;
+            }
+
+            if (taken.some(mod => matches(mod, t))) {
+                satisfied = true;
+                break;
+            }
+
+            missing.push(t);
+        }
+
+        if (!satisfied) {
+            ans.push(missing);
+        }
+    }
+
+    return ans;
+}
+
+async function getPreclusions (moduleCode) {
+    const { data, error } = await supabase
+        .from('modules')
+        .select('preclusion')
+        .eq('module_code', moduleCode)
+        .maybeSingle();
+
+    if (error) {
+        throw new Error(`Error fetching timetable: ${error.message}`);
+    }
+
+    return data?.preclusion ?? null;
+}
+
+async function fulfilledPreclusionsSoCantTakeMod (userId, moduleCode) {
+    const { data, error } = await supabase
+        .from('plan_modules')
+        .select()
+        .eq('user_id', userId)
+        .eq('status', 'taken')
+
+    if (error) {
+        throw new Error(`Error fetching timetable: ${error.message}`);
+    }
+    
+    const p = await getPreclusions(moduleCode);
+
+    if (!p) {
+        return "";
+    }
+
+    for (const { module_code : module } of data) {
+        if(p.includes(module)) {
+            return module;
+        }
+    }
+
+    return "";
+}
+
+
+async function updatePlanModules(moduleCodes, userId, status) {
+    const rows = moduleCodes.map(moduleCode => ({
+        user_id: userId,
+        module_code: moduleCode,
+        status
+    }));
+
+    const { error } = await supabase
+        .from('plan_modules')
+        .upsert(rows, {onConflict: 'user_id,module_code'});
+
+    if (error) {
+        throw new Error(`Error updating plan modules: ${error.message}`);
+    }
+}
+
+async function deletePlannedModule(userId, moduleCode) {
+    
+    const {error} = await supabase
+        .from('plan_modules')
+        .delete()
+        .eq('user_id', userId)
+        .eq('module_code', moduleCode)
+    
+    if (error) {
+        throw new Error(`Error fetching timetable: ${error.message}`);
+    }  
+}
+
+async function isModulePlanned (userId, moduleCode) {
+    const { data, error } = await supabase
+        .from('plan_modules')
+        .select('status')
+        .eq('user_id', userId)
+        .eq('module_code', moduleCode)
+        .maybeSingle();
+
+    if (error) {
+        throw new Error(`Error fetching timetable: ${error.message}`);
+    }  
+
+     if (!data) {
+        return false;
+    }
+
+    return data.status === 'planned';
+}
+
+module.exports = {
+    checkPrereq,
+    numPrereq,
+    checkPreclusion,
+    fulfillReq,
+    UserPrereqTree,
+    getPrereqModuleCodes,
+    missingPrereq,
+    getPreclusions,
+    fulfilledPreclusionsSoCantTakeMod,
+    updatePlanModules,
+    isModulePlanned,
+    matches,
+    n0f
+
+}

--- a/server/index.js
+++ b/server/index.js
@@ -12,6 +12,7 @@ const suRouter = require('./routes/su');
 const heatMapGetRouter = require('./routes/heatMap');
 const groupsRouter = require('./routes/groups');
 const groupFreeFinderRouter = require('./routes/groupFreeFinder');
+const prereqTreeRouter = require('./routes/prereqTree');
 
 
 app.use(express.json());
@@ -23,6 +24,7 @@ app.use('/su', suRouter);
 app.use('/heatmap', heatMapGetRouter);
 app.use('/api', groupsRouter);
 app.use('/api', groupFreeFinderRouter);
+app.use('/prereqTree', prereqTreeRouter);
 
 
 app.get('/health', (req, res) => {

--- a/server/routes/modules.js
+++ b/server/routes/modules.js
@@ -12,12 +12,17 @@ router.get('/', async (req, res) => {
         try {
             
             const newData = await nusmodsService.moduleGetData(b);
+            const preclusion = (newData.preclusionRule || '').match(/[A-Z]{2,4}\d{4}[A-Z]{0,3}/g) ?? [];
             await modulesDB.upsertModule({
                 module_code: newData.moduleCode,
                 module_name: newData.title,
                 semesters: newData.semesterData,
                 cached_at: new Date().toISOString(),
                 is_su_eligible: newData.attributes?.su ?? null,
+                description: newData.description,
+                prereq_tree: newData.prereqTree,
+                fulfill_requirements: newData.fulfillRequirements,
+                preclusion: preclusion,
             });
 
             return res.json(newData);

--- a/server/routes/prereqTree.js
+++ b/server/routes/prereqTree.js
@@ -1,0 +1,137 @@
+const express = require('express');
+const router = express.Router();
+const supabase = require('../db/supabase');
+const prereqTreeDB = require('../db/prereqTree');
+const qnaEligibilityDB = require('../db/qnaEligibilty');
+
+
+router.get('/prereq-tree', async (req, res) => {
+    const authHeader = req.headers.authorization;
+    if (!authHeader) {
+        return res.status(401).json({ error: 'Unauthorized' });
+    }
+    const token = authHeader.split(' ')[1];
+    
+    
+    const { data: { user }, error: authError } = await supabase.auth.getUser(token);
+    if (authError || !user) {
+        return res.status(401).json({ error: 'Unauthorized' });
+    }
+    const userID = user.id;
+    
+
+    req.user = userID;
+    try {
+        const ans = await prereqTreeDB.UserPrereqTree(userID);
+        return res.json(ans);
+    } catch (error) {
+        console.error('Error fetching data in prereq-tree', error);
+        res.status(500).json({ error: 'Internal server error' });
+    }
+
+});
+
+
+router.post('/refresh-prereq-tree', async (req, res) => {
+    const authHeader = req.headers.authorization;
+    if (!authHeader) {
+        return res.status(401).json({ error: 'Unauthorized' });
+    }
+    const token = authHeader.split(' ')[1];
+    
+    
+    const { data: { user }, error: authError } = await supabase.auth.getUser(token);
+    if (authError || !user) {
+        return res.status(401).json({ error: 'Unauthorized' });
+    }
+    const userID = user.id;
+    
+
+    req.user = userID;
+
+    try {
+        const takenModules = await qnaEligibilityDB.getEligibleModules(userID);
+        await prereqTreeDB.updatePlanModules(takenModules, userID, 'taken');
+        res.status(200).json('Success');
+    } catch (error) {
+        console.error('Error fetching data in refresh-prereq-tree', error);
+        res.status(500).json({ error: 'Internal server error' });
+    }
+
+});
+
+router.post('/add-module-tree', async (req, res) => {
+    const authHeader = req.headers.authorization;
+    if (!authHeader) {
+        return res.status(401).json({ error: 'Unauthorized' });
+    }
+    const token = authHeader.split(' ')[1];
+    
+    
+    const { data: { user }, error: authError } = await supabase.auth.getUser(token);
+    if (authError || !user) {
+        return res.status(401).json({ error: 'Unauthorized' });
+    }
+    const userID = user.id;
+
+    req.user = userID;
+    const moduleCode = req.body.module_code;
+
+    try {
+        const m = await prereqTreeDB.fulfilledPreclusionsSoCantTakeMod(userID, moduleCode);
+        if (m) {
+            return res.json({success: false,
+                preclusion: m
+            })
+        }
+        const need = await prereqTreeDB.missingPrereq(userID, moduleCode);
+
+        if (need.length === 0){
+            await prereqTreeDB.updatePlanModules([moduleCode],userID,'planned');
+            return res.json({success: true})
+        } else {
+            return res.json({success: false,
+                prereq: need
+            })
+        }
+    } catch (error) {
+        console.error('Error fetching data', error);
+        res.status(500).json({ error: 'Internal server error' });
+    }
+});
+
+router.post('/delete-planned-module', async (req, res) => {
+    const authHeader = req.headers.authorization;
+    if (!authHeader) {
+        return res.status(401).json({ error: 'Unauthorized' });
+    }
+    const token = authHeader.split(' ')[1];
+    
+    
+    const { data: { user }, error: authError } = await supabase.auth.getUser(token);
+    if (authError || !user) {
+        return res.status(401).json({ error: 'Unauthorized' });
+    }
+    const userID = user.id;
+    
+
+    req.user = userID;
+
+    const moduleCode = req.body.module_code;
+
+    try {
+        if (await prereqTreeDB.isModulePlanned(userID, moduleCode)) {
+            await prereqTreeDB.deletePlannedModule(userID, moduleCode);
+            return res.json('Module Successfully Deleted');
+        }
+
+        return res.json('Module already taken, cannot be deleted');
+    } catch (error) {
+        console.error('Error fetching data in prereq-tree', error);
+        res.status(500).json({ error: 'Internal server error' });
+    }
+
+});
+
+
+module.exports = router;


### PR DESCRIPTION
Prereq Tree / Degree Planner — Backend
Closes #49 
What this adds
Backend for the degree-planner graph: per-user planned/taken modules, prerequisite checking (with nOf support), and preclusion blocking. Builds on the modules table extension (prereq_tree, fulfill_requirements, preclusion, description) and the new plan_modules join table.
Routes — all mounted under /prereqTree
Note the prefix: /prereqTree, not /api. So full paths are /prereqTree/prereq-tree etc. (Flagging because the group features use /api — if you want these aligned to /api too, say so and I'll repoint the mount.)
All four routes require Authorization: Bearer <token> and return 401 if missing/invalid.
GET /prereqTree/prereq-tree

Returns the graph of taken modules → which taken modules are their prereqs.

Response shape:
json{ "CS2030": ["CS1010"], "CS2103T": ["CS2030"], "CS1010": [] }
Key = a taken module; value = array of the user's other taken modules that are prereqs of it. Empty array = no taken prereqs (either no prereqs, or none of them are taken). This is edge data for drawing the graph.
POST /prereqTree/add-module-tree

Body: { "module_code": "CS2103T" }

Attempts to add a module as planned. Three outcomes:
json{ "success": true }                                    // added
{ "success": false, "preclusion": "CS1020" }           // blocked: a precluded module is already taken
{ "success": false, "prereq": [ ...see below... ] }    // blocked: prereqs not met
POST /prereqTree/delete-planned-module

Body: { "module_code": "CS2103T" }

Returns a plain string (not JSON object): "Module Successfully Deleted" or "Module already taken, cannot be deleted". Only planned modules can be deleted; taken ones are locked.
POST /prereqTree/refresh-prereq-tree

Recomputes the user's taken set from their completed modules. Returns "Success". Call this after a semester's modules are finalized.
⚠️ The one shape you need to handle carefully: the prereq array
When add-module-tree returns { success: false, prereq: [...] }, prereq is an array of unsatisfied groups. The student must satisfy every group. Within a group, satisfying any one element is enough.
Each group is an array whose elements are one of two shapes:

A plain string — a module code the student is missing:

json   "CS2040"

An nOf object — "need N of these":

json   { "need": 2, "choices": ["MA1511", "MA1512"] }
So a full prereq payload can look like:
json[
  ["CS3243", "CS2109S"],
  ["MA1505", "MA2002", { "need": 1, "choices": ["MA1511", "MA1512"] }]
]
Read as: "(need one of CS3243/CS2109S) AND (need one of MA1505/MA2002, OR 1 of MA1511/MA1512)."
Frontend implication: when rendering each group, check element type — a string renders as "need X", an object renders as "need {need} of: {choices.join('/')}". A blind .map(code => ...) assuming strings will render the object as [object Object].
If you'd prefer a uniform shape (e.g. every element normalized to { type, choices, need }), tell me and I'll normalize server-side before returning — might be cleaner for your component. Your call on which is easier to render.
Assumptions baked in (so you know the limits)

Prereq trees are assumed shape: and-root or or-root → or-groups → leaves that are CODE:D strings or {nOf:[n,[...]]}. No deeper nesting. All grades assumed D (NUS passing grade). Verified against current acad-year data; a module violating this could behave unexpectedly.
add-module-tree is idempotent (upsert) — re-adding a planned module won't error, but re-adding a taken module will flip it to planned. so do not let user add taken modules can use the qna eligibility endpoint for the user taken(previous sem completed modules)

